### PR TITLE
Fix: add missing loader packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "dependencies": {
     "@vanilla-extract/babel-plugin": "^1.2.0",
     "@vanilla-extract/css": "^1.9.2",
+    "babel-loader": "^9.1.3",
+    "css-loader": "^6.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }


### PR DESCRIPTION
using another package manager like (p)npm instead of yarn throws an error on `playroom:start`